### PR TITLE
removed limit on charity count

### DIFF
--- a/data-layer-api/app.py
+++ b/data-layer-api/app.py
@@ -795,7 +795,7 @@ def get_charities():
         try:
             result = connection.execute(
                 text(
-                    "SELECT charity_id, name, status, fund, logo_url, start_date, end_date, num_listings FROM Charity LIMIT 1"),
+                    "SELECT charity_id, name, status, fund, logo_url, start_date, end_date, num_listings FROM Charity"),
             )
         except IntegrityError:
             return jsonify({}), 400


### PR DESCRIPTION
I added this as there is only supposed to be one charity active at a time. I now realize that this affects all charities, not just active ones and should be removed.